### PR TITLE
Secondary Frames

### DIFF
--- a/Source/GUI/StatsReporter/StatsReporterWidget.cpp
+++ b/Source/GUI/StatsReporter/StatsReporterWidget.cpp
@@ -7,7 +7,7 @@
 
 StatsReporterWidget::StatsReporterWidget(QWidget* parent) : QWidget(parent)
 {
-  QLabel* lblTitle = new QLabel("Stats reporter");
+  QLabel* lblTitle = new QLabel("Stats Reporter");
   lblTitle->setAlignment(Qt::AlignCenter);
 
   m_cmbSecondaryPokemon = new QComboBox;

--- a/Source/GUI/StatsReporter/StatsReporterWidget.cpp
+++ b/Source/GUI/StatsReporter/StatsReporterWidget.cpp
@@ -45,7 +45,7 @@ StatsReporterWidget::StatsReporterWidget(QWidget* parent) : QWidget(parent)
   m_tblSecondaryPossibilities->setSelectionMode(QAbstractItemView::SingleSelection);
   m_tblSecondaryPossibilities->setSelectionBehavior(QAbstractItemView::SelectRows);
   m_possibilitiesHeaderLabels = QStringList(
-      {"Seed", "Nature", "HP", "Atk", "Def", "SpA", "SpD", "Spe", "H. Power", "Gender"});
+      {"Frame", "Nature", "HP", "Atk", "Def", "SpA", "SpD", "Spe", "H. Power", "Gender", "Seed"});
   m_tblSecondaryPossibilities->setColumnCount(m_possibilitiesHeaderLabels.size());
   m_tblSecondaryPossibilities->setRowCount(0);
   m_tblSecondaryPossibilities->setHorizontalHeaderLabels(m_possibilitiesHeaderLabels);
@@ -261,6 +261,8 @@ void StatsReporterWidget::onStatsGenderChanged()
     m_tblSecondaryPossibilities->setRowCount(static_cast<int>(m_filteredCandidates.size()));
     for (int i = 0; i < m_filteredCandidates.size(); i++)
     {
+      QTableWidgetItem* frameItem = new QTableWidgetItem(
+          QString("%1").arg(m_filteredCandidates[i].frameNumber, 6, 10, QChar('0')).toUpper());
       QTableWidgetItem* seedItem = new QTableWidgetItem(
           QString("%1").arg(m_filteredCandidates[i].startingSeed, 8, 16, QChar('0')).toUpper());
       QTableWidgetItem* natureItem = new QTableWidgetItem(
@@ -283,7 +285,7 @@ void StatsReporterWidget::onStatsGenderChanged()
       QTableWidgetItem* genderItem =
           new QTableWidgetItem(m_filteredCandidates[i].properties.genderIndex ? "Female" : "Male");
 
-      m_tblSecondaryPossibilities->setItem(i, 0, seedItem);
+      m_tblSecondaryPossibilities->setItem(i, 0, frameItem);
       m_tblSecondaryPossibilities->setItem(i, 1, natureItem);
       m_tblSecondaryPossibilities->setItem(i, 2, hpItem);
       m_tblSecondaryPossibilities->setItem(i, 3, atkItem);
@@ -293,6 +295,7 @@ void StatsReporterWidget::onStatsGenderChanged()
       m_tblSecondaryPossibilities->setItem(i, 7, speedItem);
       m_tblSecondaryPossibilities->setItem(i, 8, hiddenPowerItem);
       m_tblSecondaryPossibilities->setItem(i, 9, genderItem);
+      m_tblSecondaryPossibilities->setItem(i, 10, seedItem);
     }
 
     m_tblSecondaryPossibilities->resizeColumnsToContents();

--- a/Source/PokemonRNGSystem/BaseRNGSystem.cpp
+++ b/Source/PokemonRNGSystem/BaseRNGSystem.cpp
@@ -170,8 +170,9 @@ BaseRNGSystem::predictStartersForNbrSeconds(u32 seed, const int nbrSeconds)
 }
 
 BaseRNGSystem::SecondaryCandidate BaseRNGSystem::generateSecondary(u32 seed, const Stats baseStats,
-                                                                   const int level, const u8 genderRatio, 
-																   int frameNumber)
+                                                                   const int level,
+                                                                   const u8 genderRatio,
+                                                                   int frameNumber)
 {
   SecondaryCandidate secondary;
 

--- a/Source/PokemonRNGSystem/BaseRNGSystem.cpp
+++ b/Source/PokemonRNGSystem/BaseRNGSystem.cpp
@@ -170,13 +170,14 @@ BaseRNGSystem::predictStartersForNbrSeconds(u32 seed, const int nbrSeconds)
 }
 
 BaseRNGSystem::SecondaryCandidate BaseRNGSystem::generateSecondary(u32 seed, const Stats baseStats,
-                                                                   const int level,
-                                                                   const u8 genderRatio)
+                                                                   const int level, const u8 genderRatio, 
+																   int frameNumber)
 {
   SecondaryCandidate secondary;
 
   // Every RNG call from now on influence the starters.
   secondary.startingSeed = seed;
+  secondary.frameNumber = frameNumber;
   extractIVs(secondary.properties, seed);
   // Ability, doesn't matter
   LCG(seed);
@@ -252,10 +253,12 @@ void BaseRNGSystem::generateAllSecondariesInSearchRange(const u32 postStarterSee
 {
   u32 seed = postStarterSeed;
   seed = LCGn(seed, rngAdvanceSearchStart);
+  int startingFrameNumber = rngAdvanceSearchStart - 1;
   m_secondaryCandidates.clear();
   for (int i = 0; i < searchSeedsAmount; i++)
   {
-    m_secondaryCandidates.push_back(generateSecondary(seed, baseStats, level, genderRatio));
+    m_secondaryCandidates.push_back(
+        generateSecondary(seed, baseStats, level, genderRatio, startingFrameNumber + i));
     LCG(seed);
   }
 }

--- a/Source/PokemonRNGSystem/BaseRNGSystem.h
+++ b/Source/PokemonRNGSystem/BaseRNGSystem.h
@@ -44,6 +44,7 @@ public:
     PokemonProperties properties;
     Stats stats;
     u32 startingSeed = 0;
+    int frameNumber = 0;
   };
 
   struct StartersPrediction
@@ -184,7 +185,7 @@ protected:
 
 private:
   SecondaryCandidate generateSecondary(u32 seed, const Stats baseStats, const int level,
-                                       const u8 genderRatio);
+                                       const u8 genderRatio, int frameNumber);
 
   std::vector<SecondaryCandidate> m_secondaryCandidates;
 };

--- a/Source/PokemonRNGSystem/BaseRNGSystem.h
+++ b/Source/PokemonRNGSystem/BaseRNGSystem.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <functional>
+#include <string>
 #include <vector>
 
 // This class manages all the backend and the implementation details of the RNG of a GameCube


### PR DESCRIPTION
From popular request, I have added the frame numbers to the stat predictor. This has removed the seed column and replaced with the frame number. I have also increased the bear search range as the previous one was too narrow and was unable to locate some early generated bears.
![image](https://user-images.githubusercontent.com/41100153/68917640-0efc8700-0720-11ea-8bab-ea8498a7b69f.png)

